### PR TITLE
Dont include instagram embed script more than once

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -26,12 +26,13 @@ export default class InstagramEmbed extends Component {
   }
 
   componentDidMount() {
-    if (window.instgrm) {
+    if (window.instgrm || document.getElementById('react-instagram-embed-script')) {
       this.fetchEmbed(this.getQueryParams(this.props));
     } else {
       const s = document.createElement('script')
       s.async = s.defer = true
       s.src = '//platform.instagram.com/en_US/embeds.js'
+      s.id = 'react-instagram-embed-script'
       document.body.appendChild(s)
       this.checkAPI().then(() => this.fetchEmbed(this.getQueryParams(this.props)))
     }


### PR DESCRIPTION
Bug: when including multiple embeds, the script can be included/loaded multiple times.

Cause: There's a check for `window.instgrm` before appending the script, however this variable is not set until the embed script is entirely loaded/executed.

Solution: Add an ID to the `script` tag and check for that, which works immediately without having to wait for the script to load.