### PR TITLE
Make possible to override the protocol used for loading instagram js api

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ export type Props = {
   onLoading: () => void,
   onSuccess: () => void,
   onFailure: () => void,
+  defaultProtocol: string,
 }
 type State = { __html: ?string }
 type QueryParams = { url: string, hideCaption: ?boolean, maxWidth: ?number }
@@ -22,8 +23,8 @@ export default class InstagramEmbed extends Component {
   jsonp: { promise: Promise<any>, cancel: () => void }
   _timer: number
 
-  static defaultProps: { hideCaption: boolean, containerTagName: string }
-  static defaultProps = { hideCaption: false, containerTagName: 'div' }
+  static defaultProps: { hideCaption: boolean, containerTagName: string, defaultProtocol: string }
+  static defaultProps = { hideCaption: false, containerTagName: 'div', defaultProtocol: 'https:' }
 
   state = { __html: null }
 
@@ -31,9 +32,13 @@ export default class InstagramEmbed extends Component {
     if (window.instgrm || document.getElementById('react-instagram-embed-script')) {
       this.fetchEmbed(this.getQueryParams(this.props));
     } else {
+      const protocolToUse = window.location.protocol.indexOf('file') === 0
+        ? this.props.defaultProtocol
+        : ''
+
       const s = document.createElement('script')
       s.async = s.defer = true
-      s.src = '//platform.instagram.com/en_US/embeds.js'
+      s.src = `${protocolToUse}//platform.instagram.com/en_US/embeds.js`
       s.id = 'react-instagram-embed-script'
       document.body.appendChild(s)
       this.checkAPI().then(() => this.fetchEmbed(this.getQueryParams(this.props)))
@@ -74,7 +79,7 @@ export default class InstagramEmbed extends Component {
 
   omitComponentProps(): Object {
     // eslint-disable-next-line no-unused-vars
-    const { url, hideCaption, maxWidth, containerTagName, onLoading, onSuccess, onFailure, ...rest } = this.props
+    const { url, hideCaption, maxWidth, containerTagName, onLoading, onSuccess, onFailure, defaultProtocol, ...rest } = this.props
     return rest
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ export type Props = {
   onLoading: () => void,
   onSuccess: () => void,
   onFailure: () => void,
-  defaultProtocol: string,
+  protocol: string,
 }
 type State = { __html: ?string }
 type QueryParams = { url: string, hideCaption: ?boolean, maxWidth: ?number }
@@ -23,8 +23,8 @@ export default class InstagramEmbed extends Component {
   jsonp: { promise: Promise<any>, cancel: () => void }
   _timer: number
 
-  static defaultProps: { hideCaption: boolean, containerTagName: string, defaultProtocol: string }
-  static defaultProps = { hideCaption: false, containerTagName: 'div', defaultProtocol: 'https:' }
+  static defaultProps: { hideCaption: boolean, containerTagName: string, protocol: string }
+  static defaultProps = { hideCaption: false, containerTagName: 'div', protocol: 'https:' }
 
   state = { __html: null }
 
@@ -33,7 +33,7 @@ export default class InstagramEmbed extends Component {
       this.fetchEmbed(this.getQueryParams(this.props));
     } else {
       const protocolToUse = window.location.protocol.indexOf('file') === 0
-        ? this.props.defaultProtocol
+        ? this.props.protocol
         : ''
 
       const s = document.createElement('script')
@@ -79,7 +79,7 @@ export default class InstagramEmbed extends Component {
 
   omitComponentProps(): Object {
     // eslint-disable-next-line no-unused-vars
-    const { url, hideCaption, maxWidth, containerTagName, onLoading, onSuccess, onFailure, defaultProtocol, ...rest } = this.props
+    const { url, hideCaption, maxWidth, containerTagName, onLoading, onSuccess, onFailure, protocol, ...rest } = this.props
     return rest
   }
 


### PR DESCRIPTION
Cordova apps are served from device's file system. Hence, all ``//something.com`` resources will inherit the ``file://`` protocol by default.
This patch prevents that from happening by defaulting to ``https://``. This default can be overridden through ``defaultProtocol`` prop.