### PR TITLE
Moved onSuccess call after render call

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -115,11 +115,11 @@ export default class InstagramEmbed extends Component {
   }
 
   handleFetchSuccess = (response: Object): void => {
-    this.props.onSuccess && this.props.onSuccess(response)
     this.setState(
       { __html: response.html },
       () => window.instgrm.Embeds.process()
     )
+    this.props.onSuccess && this.props.onSuccess(response)
   }
 
   handleFetchFailure = (...args: any): void => {

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ export type Props = {
   containerTagName: string,
   onLoading: () => void,
   onSuccess: () => void,
+  onAfterRender: () => void,
   onFailure: () => void,
   protocol: string,
 }
@@ -56,7 +57,7 @@ export default class InstagramEmbed extends Component {
   }
 
   shouldComponentUpdate(nextProps: Props, nextState: State): boolean {
-    const { url, hideCaption, maxWidth, containerTagName, onLoading, onSuccess, onFailure } = this.props
+    const { url, hideCaption, maxWidth, containerTagName, onLoading, onSuccess, onAfterRender onFailure } = this.props
     const { __html } = this.state
     if (nextProps.url !== url ||
         nextProps.hideCaption !== hideCaption ||
@@ -64,6 +65,7 @@ export default class InstagramEmbed extends Component {
         nextProps.containerTagName !== containerTagName ||
         nextProps.onLoading !== onLoading ||
         nextProps.onSuccess !== onSuccess ||
+        nextProps.onAfterRender !== onAfterRender ||
         nextProps.onFailure !== onFailure ||
         nextState.__html !== __html) {
       return true
@@ -78,7 +80,7 @@ export default class InstagramEmbed extends Component {
 
   omitComponentProps(): Object {
     // eslint-disable-next-line no-unused-vars
-    const { url, hideCaption, maxWidth, containerTagName, onLoading, onSuccess, onFailure, protocol, ...rest } = this.props
+    const { url, hideCaption, maxWidth, containerTagName, onLoading, onSuccess, onAfterRender, onFailure, protocol, ...rest } = this.props
     return rest
   }
 
@@ -115,11 +117,12 @@ export default class InstagramEmbed extends Component {
   }
 
   handleFetchSuccess = (response: Object): void => {
+    this.props.onSuccess && this.props.onSuccess(response)
     this.setState(
       { __html: response.html },
       () => window.instgrm.Embeds.process()
     )
-    this.props.onSuccess && this.props.onSuccess(response)
+    this.props.onAfterRender && this.props.onAfterRender(response)
   }
 
   handleFetchFailure = (...args: any): void => {

--- a/src/index.js
+++ b/src/index.js
@@ -121,8 +121,8 @@ export default class InstagramEmbed extends Component {
     this.setState(
       { __html: response.html },
       () => window.instgrm.Embeds.process()
+            this.props.onAfterRender && this.props.onAfterRender(response)
     )
-    this.props.onAfterRender && this.props.onAfterRender(response)
   }
 
   handleFetchFailure = (...args: any): void => {


### PR DESCRIPTION
In order to get the dimensions (e.g. clientHeight, clientWidth) of the embed it needs to be rendered to the screen. This is why the onSuccess call is better made after the internal state update that causes the rerender.
Alternatively there could be an additional callback such as `onRender`. But since I didn’t see any particular advantage of placing the onSuccess call before the render, it is easier to just move it to the end. Hope this makes sense :)