### PR TITLE
ADDED canceling request in componentWillUnmount

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -80,6 +80,10 @@ export default class InstagramEmbed extends Component {
     return <this.props.containerTagName {...this.omitComponentProps()} dangerouslySetInnerHTML={{ __html: this.state.__html }} />
   }
 
+  componentWillUnmount() {
+    this.cancel()
+  }
+
   omitComponentProps(): Object {
     // eslint-disable-next-line no-unused-vars
     const { url, hideCaption, maxWidth, containerTagName, onLoading, onSuccess, onAfterRender, onFailure, protocol, ...rest } = this.props

--- a/src/index.js
+++ b/src/index.js
@@ -139,5 +139,9 @@ export default class InstagramEmbed extends Component {
   }
 
   // Public
-  cancel = (): void => this.jsonp.cancel()
+  cancel = (): void => {
+    if (this.jsonp) {
+      this.jsonp.cancel()
+    }
+  }
 }


### PR DESCRIPTION
If you use embed when hovering on an element, you can get an error if you remove the hover before loading is complete 

> Warning: setState(...): Can only update a mounted or mounting component. This usually means you called setState() on an unmounted component. This is a no-op. Please check the code for the InstagramEmbed component.