### PR TITLE
Fixed an issue where multiple widgets could not be expanded on initial loading

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ export type Props = {
   onAfterRender: () => void,
   onFailure: () => void,
   protocol: string,
+  injectScript: boolean
 }
 type State = { __html: ?string }
 type QueryParams = { url: string, hideCaption: boolean, maxWidth: number }
@@ -20,18 +21,18 @@ type RequestPromise = { promise: Promise<any>, cancel: () => void }
 
 export default class InstagramEmbed extends Component<Props, State> {
   request: RequestPromise
+  _timer: TimeoutID
 
-  static defaultProps = { hideCaption: false, containerTagName: 'div', protocol: 'https:' }
+  static defaultProps = { hideCaption: false, containerTagName: 'div', protocol: 'https:', injectScript: true }
 
   state = { __html: null }
 
   componentDidMount() {
-    if (window.instgrm) {
+    if (window.instgrm || document.getElementById('react-instagram-embed-script')) {
       this.fetchEmbed(this.getQueryParams(this.props))
     } else {
-      this.injectScript(() => {
-        this.fetchEmbed(this.getQueryParams(this.props))
-      })
+      if (this.props.injectScript) { this.injectScript() }
+      this.checkAPI().then(() => this.fetchEmbed(this.getQueryParams(this.props)))
     }
   }
 
@@ -78,33 +79,34 @@ export default class InstagramEmbed extends Component<Props, State> {
     return rest
   }
 
-  injectScript(cb: Function): void {
-    const scriptElement: HTMLElement | null = document.getElementById('react-instagram-embed-script')
-    const onLoadEventListenerOnce = (ele: HTMLElement, func: Function) => {
-      ele.addEventListener("load", (() => {
-        return cb = () => {
-          func()
-          ele.removeEventListener("load", cb)
-        }
-      })())
-    }
-    if (!scriptElement) {
-      const protocolToUse: string = window.location.protocol.indexOf('file') === 0
-        ? this.props.protocol
-        : ''
+  injectScript(): void {
+    const protocolToUse: string = window.location.protocol.indexOf('file') === 0
+      ? this.props.protocol
+      : ''
 
-      const s = document.createElement('script')
-      s.async = s.defer = true
-      s.src = `${protocolToUse}//platform.instagram.com/en_US/embeds.js`
-      s.id = 'react-instagram-embed-script'
-      onLoadEventListenerOnce(s, cb)
-      const body: HTMLElement | null = document.body
-      if (body) {
-        body.appendChild(s)
-      }
-    } else {
-      onLoadEventListenerOnce(scriptElement, cb)
+    const s = document.createElement('script')
+    s.async = s.defer = true
+    s.src = `${protocolToUse}//platform.instagram.com/en_US/embeds.js`
+    s.id = 'react-instagram-embed-script'
+    const body: HTMLElement | null = document.body
+    if (body) {
+      body.appendChild(s)
     }
+  }
+
+  checkAPI(): Promise<any> {
+    return new Promise(resolve => {
+      (function checkAPI(_this) {
+        _this._timer = setTimeout(() => {
+          if (window.instgrm) {
+            clearTimeout(_this._timer)
+            resolve()
+          } else {
+            checkAPI(_this)
+          }
+        }, 20)
+      })(this)
+    })
   }
 
   fetchEmbed(queryParams: string): void {
@@ -136,6 +138,7 @@ export default class InstagramEmbed extends Component<Props, State> {
   }
 
   handleFetchFailure = (...args: any): void => {
+    clearTimeout(this._timer)
     this.props.onFailure && this.props.onFailure(...args)
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -28,10 +28,12 @@ export default class InstagramEmbed extends Component<Props, State> {
   state = { __html: null }
 
   componentDidMount() {
-    if (window.instgrm || document.getElementById('react-instagram-embed-script')) {
+    if (window.instgrm) {
       this.fetchEmbed(this.getQueryParams(this.props))
     } else {
-      if (this.props.injectScript) { this.injectScript() }
+      if (this.props.injectScript && !document.getElementById('react-instagram-embed-script')) {
+        this.injectScript()
+      }
       this.checkAPI().then(() => this.fetchEmbed(this.getQueryParams(this.props)))
     }
   }


### PR DESCRIPTION
英語が苦手なので日本語で失礼します。

初回ロード時に2つ以上のウィジェットを展開しようとすると`react-instagram-embed-script`idのエレメントが存在していて且つ`window.instgrm`が存在しない状況があり展開に失敗する問題があましたので修正致しました。
恐らく #21 の問題の解決になるかと思います。

Because I am not good at English, I am rude in Japanese.

When trying to expand more than two widgets at the time of initial loading, there was a problem that the elements of `react-instagram-embed-script`id existed and there was no `window.instgrm` and there was a problem that the deployment failed I fixed it.
I think that it will probably be a solution to the problem of #21.