### PR TITLE
Update graph API from v8.0 -> v11.0

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -109,7 +109,7 @@ export default class InstagramEmbed extends React.PureComponent<Props, State> {
   };
 
   private fetchEmbed(queryParams: string): void {
-    this.request = this.createRequestPromise(`https://graph.facebook.com/v8.0/instagram_oembed/?${queryParams}`);
+    this.request = this.createRequestPromise(`https://graph.facebook.com/v11.0/instagram_oembed/?${queryParams}`);
 
     if (this.props.onLoading) {
       this.props.onLoading();


### PR DESCRIPTION
Facebook is deprecating the oEmbed product in favor of oEmbed Read starting September 7, 2021.

> The oEmbed product has been replaced with the oEmbed Read feature. If you implemented the oEmbed product before June 8, 2021, you have until September 7, 2021 to complete App Review for the oEmbed Read feature. If you have not been approved for the oEmbed Read feature by September 7, 2021, your oEmbed implementations will fail to load.

https://developers.facebook.com/docs/plugins/oembed/